### PR TITLE
Empty root node

### DIFF
--- a/code/collaborative-optimizer/experiment_graph/execution_environment.py
+++ b/code/collaborative-optimizer/experiment_graph/execution_environment.py
@@ -214,8 +214,16 @@ class ExecutionEnvironment(object):
             return self.workload_dag.get_node(identifier)['data']
 
         if node_type == 'Dataset':
-            return Dataset(identifier, self)
+            nextnode = Dataset(identifier, self, underlying_data=DataFrame([], [], pd.DataFrame()))
         elif node_type == 'Feature':
-            return Feature(identifier, self)
+            nextnode = Feature(identifier, self, underlying_data=DataSeries('', '', pd.Series()))
         else:
             raise TypeError(f'Unknown Data Type: {node_type}')
+
+        self.workload_dag.roots.append(identifier)
+        self.workload_dag.add_node(identifier,
+                                   **{'root': True, 'type': node_type, 'data': nextnode,
+                                      'loc': identifier,
+                                      'extra_params': 'empty_node',
+                                      'size': None})
+        return nextnode

--- a/code/collaborative-optimizer/experiment_graph/execution_environment.py
+++ b/code/collaborative-optimizer/experiment_graph/execution_environment.py
@@ -208,3 +208,14 @@ class ExecutionEnvironment(object):
                                           'extra_params': 'load_from_memory',
                                           'size': None})
             return nextnode
+
+    def empty_node(self, node_type='Dataset', identifier='empty_root'):
+        if self.workload_dag.has_node(identifier):
+            return self.workload_dag.get_node(identifier)['data']
+
+        if node_type == 'Dataset':
+            return Dataset(identifier, self)
+        elif node_type == 'Feature':
+            return Feature(identifier, self)
+        else:
+            raise TypeError(f'Unknown Data Type: {node_type}')

--- a/code/collaborative-optimizer/experiment_graph/execution_environment.py
+++ b/code/collaborative-optimizer/experiment_graph/execution_environment.py
@@ -126,17 +126,7 @@ class ExecutionEnvironment(object):
         else:
             return self.experiment_graph.get_artifact_sizes()
 
-    def load(self, loc, dtype=None, nrows=None, parse_dates=False, date_parser=None):
-        extra_params = dict()
-        if dtype is not None:
-            extra_params['dtype'] = dtype
-        if nrows is not None:
-            extra_params['nrows'] = nrows
-        if not parse_dates:
-            extra_params['parse_dates'] = parse_dates
-        if date_parser is not None:
-            extra_params['date_parser'] = date_parser
-
+    def load(self, loc, **extra_params):
         root_hash = self.construct_readable_root_hash(loc, extra_params)
         if self.workload_dag.has_node(root_hash):
             # print 'loading root node {} from workload graph'.format(root_hash)
@@ -152,7 +142,7 @@ class ExecutionEnvironment(object):
         else:
             print('creating a new root node')
             start = datetime.now()
-            initial_data = pd.read_csv(loc, dtype=dtype, nrows=nrows, parse_dates=parse_dates, date_parser=date_parser)
+            initial_data = pd.read_csv(loc, **extra_params)
             end = datetime.now()
             self.update_time(BenchmarkMetrics.LOAD_DATASET, (end - start).total_seconds())
             c_name = []
@@ -214,7 +204,7 @@ class ExecutionEnvironment(object):
 
         :param node_type: type of the node object (currently, only supports Dataset and Feature)
         :param identifier: unique identifier used for looking up the node in graph. Use this if you want to create
-                           multiple empty nodes to differentiate between them.  
+                           multiple empty nodes to differentiate between them.
         :return:
         """
         if self.workload_dag.has_node(identifier):

--- a/code/collaborative-optimizer/experiment_graph/execution_environment.py
+++ b/code/collaborative-optimizer/experiment_graph/execution_environment.py
@@ -210,6 +210,13 @@ class ExecutionEnvironment(object):
             return nextnode
 
     def empty_node(self, node_type='Dataset', identifier='empty_root'):
+        """
+
+        :param node_type: type of the node object (currently, only supports Dataset and Feature)
+        :param identifier: unique identifier used for looking up the node in graph. Use this if you want to create
+                           multiple empty nodes to differentiate between them.  
+        :return:
+        """
         if self.workload_dag.has_node(identifier):
             return self.workload_dag.get_node(identifier)['data']
 

--- a/code/collaborative-optimizer/tests/test_execution_environment.py
+++ b/code/collaborative-optimizer/tests/test_execution_environment.py
@@ -14,9 +14,11 @@ class TestExecutionEnvironment(TestCase):
         def run(self, underlying_data):
             return pd.read_csv(self.path)
 
-    def test_empty_node(self):
+    def test_empty_dataset(self):
         execution_environment = ExecutionEnvironment()
-        empty_data = execution_environment.empty_node()
+        empty_data = execution_environment.empty_node(node_type='Dataset')
         load_oper = TestExecutionEnvironment.LoadWithData('data/openml/task_id=31/datasets/train.csv')
         loaded_data = empty_data.run_udf(load_oper)
-        print(loaded_data.data())
+        print(loaded_data.data().head())
+        print(f'columns: {loaded_data.get_column()}')
+        print(f'column hashes: {loaded_data.get_column_hash()}')

--- a/code/collaborative-optimizer/tests/test_execution_environment.py
+++ b/code/collaborative-optimizer/tests/test_execution_environment.py
@@ -22,3 +22,8 @@ class TestExecutionEnvironment(TestCase):
         print(loaded_data.data().head())
         print(f'columns: {loaded_data.get_column()}')
         print(f'column hashes: {loaded_data.get_column_hash()}')
+
+    def test_load_csv_with_options(self):
+        execution_environment = ExecutionEnvironment()
+        data_with_option = execution_environment.load('data/openml/task_id=31/datasets/train.csv', nrows=100)
+        print(data_with_option.data())

--- a/code/collaborative-optimizer/tests/test_execution_environment.py
+++ b/code/collaborative-optimizer/tests/test_execution_environment.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+import pandas as pd
+
+from execution_environment import ExecutionEnvironment, UserDefinedFunction
+
+
+class TestExecutionEnvironment(TestCase):
+    class LoadWithData(UserDefinedFunction):
+        def __init__(self, path):
+            super().__init__(return_type='Dataset')
+            self.path = path
+
+        def run(self, underlying_data):
+            return pd.read_csv(self.path)
+
+    def test_empty_node(self):
+        execution_environment = ExecutionEnvironment()
+        empty_data = execution_environment.empty_node()
+        load_oper = TestExecutionEnvironment.LoadWithData('data/openml/task_id=31/datasets/train.csv')
+        loaded_data = empty_data.run_udf(load_oper)
+        print(loaded_data.data())


### PR DESCRIPTION
1. Create an empty root node using ```execution_environment.empty_node(node_type='Dataset')```.
2. Allows options for loading pandas csv files to be passed to ```execution_environment.load()```.
Currently, it supports only Dataset and Feature (default is Dataset) node.
Check the unit test ```code/collaborative-optimizer/tests/test_execution_environment.py``` for usage example.