### PR TITLE
Unmaterializable nodes

### DIFF
--- a/code/collaborative-optimizer/experiment_graph/graph/node.py
+++ b/code/collaborative-optimizer/experiment_graph/graph/node.py
@@ -20,7 +20,7 @@ AS_KB = 1024.0
 
 
 class Node(object):
-    def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
+    def __init__(self, node_id, execution_environment, underlying_data=None, size=None, unmaterializable=False):
         self.id = node_id
         self.computed = False
         self.access_freq = 0
@@ -28,6 +28,7 @@ class Node(object):
         self.size = size
         self.underlying_data = underlying_data
         self.computed = False if underlying_data is None else True
+        self.unmaterializable = unmaterializable
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -112,13 +113,13 @@ class Node(object):
             return nextnode
 
     # TODO: need to implement eager_mode when needed
-    def generate_agg_node(self, oper, args=None, v_id=None, eager_mode=0):
+    def generate_agg_node(self, oper, args=None, v_id=None, unmaterializable=False):
         v_id = self.id if v_id is None else v_id
         args = {} if args is None else args
         # nextid = self.generate_uuid()
         edge_hash = self.edge_hash(oper, args)
         nextid = self.vertex_hash(v_id, edge_hash)
-        nextnode = Agg(nextid, self.execution_environment)
+        nextnode = Agg(nextid, self.execution_environment, unmaterializable=unmaterializable)
         exist = self.execution_environment.workload_dag.add_edge(v_id, nextid, nextnode,
                                                                  {'name': oper,
                                                                   'oper': 'p_' + oper,
@@ -146,7 +147,7 @@ class Node(object):
                                                                  ntype=GroupBy.__name__)
         return self.get_not_none(nextnode, exist)
 
-    def generate_sklearn_node(self, oper, args=None, v_id=None, should_warmstart=False):
+    def generate_sklearn_node(self, oper, args=None, v_id=None, should_warmstart=False, unmaterializable=False):
         v_id = self.id if v_id is None else v_id
         args = {} if args is None else args
         edge_arguments = dict()
@@ -161,7 +162,7 @@ class Node(object):
                 edge_arguments['no_random_state_model'] = str(no_random_state_model)
         edge_hash = self.edge_hash(oper, args)
         nextid = self.vertex_hash(v_id, edge_hash)
-        nextnode = SK_Model(nextid, self.execution_environment)
+        nextnode = SK_Model(nextid, self.execution_environment, unmaterializable=unmaterializable)
         edge_arguments['name'] = type(args['model']).__name__
         edge_arguments['oper'] = 'p_' + oper
         edge_arguments['args'] = args
@@ -173,7 +174,7 @@ class Node(object):
                                                                  ntype=SK_Model.__name__)
         return self.get_not_none(nextnode, exist)
 
-    def generate_dataset_node(self, oper, args=None, v_id=None):
+    def generate_dataset_node(self, oper, args=None, v_id=None, unmaterializable=False):
         v_id = self.id if v_id is None else v_id
         args = {} if args is None else args
         # c_name = [] if c_name is None else c_name
@@ -181,7 +182,7 @@ class Node(object):
         # nextid = self.generate_uuid()
         edge_hash = self.edge_hash(oper, args)
         nextid = self.vertex_hash(v_id, edge_hash)
-        nextnode = Dataset(nextid, self.execution_environment)
+        nextnode = Dataset(nextid, self.execution_environment, unmaterializable=unmaterializable)
         exist = self.execution_environment.workload_dag.add_edge(v_id, nextid, nextnode,
                                                                  {'name': oper,
                                                                   'oper': 'p_' + oper,
@@ -192,13 +193,13 @@ class Node(object):
                                                                  ntype=Dataset.__name__)
         return self.get_not_none(nextnode, exist)
 
-    def generate_feature_node(self, oper, args=None, v_id=None):
+    def generate_feature_node(self, oper, args=None, v_id=None, unmaterializable=False):
         v_id = self.id if v_id is None else v_id
         args = {} if args is None else args
         # nextid = self.generate_uuid()
         edge_hash = self.edge_hash(oper, args)
         nextid = self.vertex_hash(v_id, edge_hash)
-        nextnode = Feature(nextid, self.execution_environment)
+        nextnode = Feature(nextid, self.execution_environment, unmaterializable=unmaterializable)
         exist = self.execution_environment.workload_dag.add_edge(v_id, nextid, nextnode,
                                                                  {'name': oper,
                                                                   'execution_time': -1,
@@ -258,11 +259,13 @@ class Node(object):
             # TODO: add the update rule (even though it has no effect)
             return self.execution_environment.workload_dag.graph.nodes[nextid]['data']
 
-    def run_udf(self, operation: UserDefinedFunction, other_inputs: "Node" or List["Node"] = None):
+    def run_udf(self, operation: UserDefinedFunction, other_inputs: "Node" or List["Node"] = None,
+                unmaterializable_result=False):
         """
 
         :param operation:
         :param other_inputs: For multi-input operators, this argument must be passed.
+        :param unmaterializable_result: set True if the result of running this operation should not be materialized
         :return:
         """
         super_node_id = None
@@ -277,13 +280,17 @@ class Node(object):
 
         return_type = operation.return_type
         if return_type == Dataset.__name__:
-            return self.generate_dataset_node('udf', args={'operation': operation}, v_id=super_node_id)
+            return self.generate_dataset_node('udf', args={'operation': operation}, v_id=super_node_id,
+                                              unmaterializable=unmaterializable_result)
         elif return_type == Feature.__name__:
-            return self.generate_feature_node('udf', args={'operation': operation}, v_id=super_node_id)
+            return self.generate_feature_node('udf', args={'operation': operation}, v_id=super_node_id,
+                                              unmaterializable=unmaterializable_result)
         elif return_type == Agg.__name__:
-            return self.generate_agg_node('udf', args={'operation': operation}, v_id=super_node_id)
+            return self.generate_agg_node('udf', args={'operation': operation}, v_id=super_node_id,
+                                          unmaterializable=unmaterializable_result)
         elif return_type == SK_Model.__name__:
-            return self.generate_sklearn_node('udf', args={'operation': operation}, v_id=super_node_id)
+            return self.generate_sklearn_node('udf', args={'operation': operation}, v_id=super_node_id,
+                                              unmaterializable=unmaterializable_result)
         else:
             raise TypeError('Invalid return type: {}'.format(return_type))
 
@@ -341,7 +348,7 @@ class Node(object):
 
 class Agg(Node):
 
-    def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
+    def __init__(self, node_id, execution_environment, underlying_data=None, size=None, unmaterializable=False):
         Node.__init__(self, node_id, execution_environment, underlying_data, size)
 
     def clear_content(self):
@@ -388,12 +395,12 @@ class Dataset(Node):
 
     """
 
-    def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
+    def __init__(self, node_id, execution_environment, underlying_data=None, size=None, unmaterializable=False):
         """
 
         :type underlying_data: DataFrame
         """
-        Node.__init__(self, node_id, execution_environment, underlying_data, size)
+        Node.__init__(self, node_id, execution_environment, underlying_data, size, unmaterializable)
 
     def clear_content(self):
         del self.underlying_data
@@ -861,12 +868,12 @@ class Feature(Node):
 
     """
 
-    def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
+    def __init__(self, node_id, execution_environment, underlying_data=None, size=None, unmaterializable=False):
         """
 
         :type underlying_data: DataSeries
         """
-        Node.__init__(self, node_id, execution_environment, underlying_data, size)
+        Node.__init__(self, node_id, execution_environment, underlying_data, size, unmaterializable)
 
     def clear_content(self):
         self.underlying_data = None
@@ -1322,7 +1329,7 @@ class GroupBy(Node):
 
 
 class SK_Model(Node):
-    def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
+    def __init__(self, node_id, execution_environment, underlying_data=None, size=None, unmaterializable=False):
         Node.__init__(self, node_id, execution_environment, underlying_data, size)
         self.model_score = 0.0
 

--- a/code/collaborative-optimizer/experiment_graph/graph/node.py
+++ b/code/collaborative-optimizer/experiment_graph/graph/node.py
@@ -28,7 +28,17 @@ class Node(object):
         self.size = size
         self.underlying_data = underlying_data
         self.computed = False if underlying_data is None else True
-        self.unmaterializable = unmaterializable
+        self._unmaterializable = unmaterializable
+
+    @property
+    def unmaterializable(self):
+        return self._unmaterializable
+
+    @unmaterializable.setter
+    def unmaterializable(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError('Unmaterializable can only be a boolean')
+        self._unmaterializable = value
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -1203,7 +1213,13 @@ class Feature(Node):
 class GroupBy(Node):
 
     def __init__(self, node_id, execution_environment, underlying_data=None, size=None):
-        Node.__init__(self, node_id, execution_environment, underlying_data, size)
+        Node.__init__(self, node_id, execution_environment, underlying_data, size, unmaterializable=True)
+
+    @Node.unmaterializable.setter
+    def unmaterializable(self, value: bool):
+        if not value:
+            raise ValueError('Cannot set unmaterializable = False for SuperNodes')
+        self._unmaterializable = value
 
     def clear_content(self):
         del self.underlying_data
@@ -1431,8 +1447,14 @@ class SuperNode(Node):
     """
 
     def __init__(self, node_id, execution_environment, nodes):
-        Node.__init__(self, node_id, execution_environment, underlying_data=None, size=0.0)
+        Node.__init__(self, node_id, execution_environment, underlying_data=None, size=0.0, unmaterializable=True)
         self.nodes = nodes
+
+    @Node.unmaterializable.setter
+    def unmaterializable(self, value: bool):
+        if not value:
+            raise ValueError('Cannot set unmaterializable = False for SuperNodes')
+        self._unmaterializable = value
 
     def clear_content(self):
         pass

--- a/code/collaborative-optimizer/tests/experiment_graph/optimizations/test_Reuse.py
+++ b/code/collaborative-optimizer/tests/experiment_graph/optimizations/test_Reuse.py
@@ -61,7 +61,7 @@ class TestReuse(TestCase):
         self.min_max_reuse = ReuseMinMaxWorkload()
         self.executor = HelixExecutor()
         self.base_workload = BaseWorkload()
-        self.root_data = '../../data'
+        self.root_data = 'data'
 
     def test_run_helix(self):
         self.executor.end_to_end_run(self.base_workload, root_data=self.root_data, verbose=1)

--- a/code/collaborative-optimizer/tests/test_node.py
+++ b/code/collaborative-optimizer/tests/test_node.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+import pandas as pd
+
+from execution_environment import ExecutionEnvironment, UserDefinedFunction, SuperNode, GroupBy
+
+
+class TestNode(TestCase):
+    def setUp(self) -> None:
+        self.execution_environment = ExecutionEnvironment()
+
+    def test_set_super_node_as_materializable(self):
+        super_node = SuperNode('id', self.execution_environment, [])
+        with self.assertRaises(ValueError):
+            super_node.unmaterializable = False
+
+        groupby_node = GroupBy('group-id', self.execution_environment)
+        with self.assertRaises(ValueError):
+            groupby_node.unmaterializable = False
+
+
+    def test_unmaterializable_nodes(self):
+        class IdentityFunction(UserDefinedFunction):
+            def __init__(self):
+                super().__init__(return_type='Dataset')
+
+            def run(self, underlying_data):
+                # here the underlying_data is a pandas dataframe and we are directly calling the pandas clip function
+                return underlying_data
+
+        data = self.execution_environment.load('data/sample.csv')
+
+        identity_function = IdentityFunction()
+        unmaterializable_dataset = data.run_udf(operation=identity_function, unmaterializable_result=True)
+
+        unmaterializable_dataset.data()
+
+

--- a/code/collaborative-optimizer/tests/test_node.py
+++ b/code/collaborative-optimizer/tests/test_node.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
 
-import pandas as pd
-
 from execution_environment import ExecutionEnvironment, UserDefinedFunction, SuperNode, GroupBy
 
 
@@ -9,7 +7,7 @@ class TestNode(TestCase):
     def setUp(self) -> None:
         self.execution_environment = ExecutionEnvironment()
 
-    def test_set_super_node_as_materializable(self):
+    def test_set_super_node_cannot_be_materializable(self):
         super_node = SuperNode('id', self.execution_environment, [])
         with self.assertRaises(ValueError):
             super_node.unmaterializable = False
@@ -17,7 +15,6 @@ class TestNode(TestCase):
         groupby_node = GroupBy('group-id', self.execution_environment)
         with self.assertRaises(ValueError):
             groupby_node.unmaterializable = False
-
 
     def test_unmaterializable_nodes(self):
         class IdentityFunction(UserDefinedFunction):
@@ -34,5 +31,3 @@ class TestNode(TestCase):
         unmaterializable_dataset = data.run_udf(operation=identity_function, unmaterializable_result=True)
 
         unmaterializable_dataset.data()
-
-

--- a/code/collaborative-optimizer/tests/test_node.py
+++ b/code/collaborative-optimizer/tests/test_node.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
+from nose_parameterized import parameterized
+
 from execution_environment import ExecutionEnvironment, UserDefinedFunction, SuperNode, GroupBy
+from executor import CollaborativeExecutor
+from materialization_methods import AllMaterializer, HeuristicsMaterializer, StorageAwareMaterializer, HelixMaterializer
 
 
 class TestNode(TestCase):
@@ -16,7 +20,13 @@ class TestNode(TestCase):
         with self.assertRaises(ValueError):
             groupby_node.unmaterializable = False
 
-    def test_unmaterializable_nodes(self):
+    @parameterized.expand([
+        ('AllMaterializer', AllMaterializer()),
+        ('HeuristicsMaterializer', HeuristicsMaterializer(1000)),
+        ('StorageAwareMaterializer', StorageAwareMaterializer(1000)),
+        ('HelixMaterializer', HelixMaterializer(1000))
+    ])
+    def test_unmaterializable_nodes(self, name, materializer):
         class IdentityFunction(UserDefinedFunction):
             def __init__(self):
                 super().__init__(return_type='Dataset')
@@ -25,9 +35,28 @@ class TestNode(TestCase):
                 # here the underlying_data is a pandas dataframe and we are directly calling the pandas clip function
                 return underlying_data
 
+        executor = CollaborativeExecutor(execution_environment=self.execution_environment,
+                                         materializer=materializer)
+        print(self.execution_environment.experiment_graph.graph.nodes())
         data = self.execution_environment.load('data/sample.csv')
-
         identity_function = IdentityFunction()
-        unmaterializable_dataset = data.run_udf(operation=identity_function, unmaterializable_result=True)
+        # Normal call, result is materializable, hash = E2C4590331CE548DB3614C3AF20B7177
+        materializable_dataset = data.run_udf(operation=identity_function)
+        materializable_dataset.data()
 
+        # Result is unmaterializable hash = C7064173E8FE5BF4E661D546091DE811
+        unmaterializable_dataset = materializable_dataset.run_udf(operation=identity_function,
+                                                                  unmaterializable_result=True)
         unmaterializable_dataset.data()
+
+        # Calling the post processing and materialization
+        executor.local_process()
+        executor.global_process()
+
+        history_graph = executor.execution_environment.experiment_graph.graph
+
+        # E2C4590331CE548DB3614C3AF20B7177
+        self.assertTrue(history_graph.nodes['E2C4590331CE548DB3614C3AF20B7177']['mat'])
+
+        # C7064173E8FE5BF4E661D546091DE811
+        self.assertFalse(history_graph.nodes['C7064173E8FE5BF4E661D546091DE811']['mat'])

--- a/code/collaborative-optimizer/tests/test_operations.py
+++ b/code/collaborative-optimizer/tests/test_operations.py
@@ -34,7 +34,7 @@ class TestExecutionEnvironment(TestCase):
             def __init__(self):
                 super().__init__(return_type='Dataset')
 
-            def run(self, underlying_data):
+            def run(self, *underlying_data):
                 """
                 Here, we assume underlying_data is a list of only 2 dataframes
                 :param underlying_data:
@@ -57,7 +57,7 @@ class TestExecutionEnvironment(TestCase):
             def __init__(self):
                 super().__init__(return_type='Dataset')
 
-            def run(self, underlying_data):
+            def run(self, *underlying_data):
                 """
                 Here, we assume underlying_data is a list of multiple dataframes
                 :param underlying_data:


### PR DESCRIPTION
Adds support for unmaterializable nodes.
To make the result of udf calls unmaterializable, pass  unmaterializable_result=False to te run_udf function.
```
def run_udf(self, operation: UserDefinedFunction, other_inputs: "Node" or List["Node"] = None, unmaterializable_result=False):
```